### PR TITLE
Use uring for networking and file system operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ percent-encoding = "2"
 time = { version = "0.3.7", features = ["parsing", "formatting", "macros"] }
 # Range because of vulnerability https://rustsec.org/advisories/RUSTSEC-2023-0001.html
 tokio = { version = "1, >=1.23.1", features = ["rt", "io-util", "fs", "sync", "parking_lot", "time"] }
+tokio-uring = { git = "https://github.com/tokio-rs/tokio-uring", features = ["bytes"] }
 moka = { version = "0.10.0", features = ["future"], default-features = false }
 
 # HTTPS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ mime_guess = "2"
 percent-encoding = "2"
 time = { version = "0.3.7", features = ["parsing", "formatting", "macros"] }
 # Range because of vulnerability https://rustsec.org/advisories/RUSTSEC-2023-0001.html
-tokio = { version = "1, >=1.23.1", features = ["rt", "io-util", "fs", "sync", "parking_lot", "time"] }
-tokio-uring = { git = "https://github.com/tokio-rs/tokio-uring", features = ["bytes"] }
+tokio = { version = "1, >=1.23.1", features = ["rt", "io-util", "fs", "sync", "parking_lot", "time", "macros"] }
+tokio-uring = { git = "https://github.com/tokio-rs/tokio-uring", features = ["bytes"], optional = true }
 moka = { version = "0.10.0", features = ["future"], default-features = false }
 
 # HTTPS
@@ -88,7 +88,7 @@ gzip = ["flate2"]
 
 # HTTP standards
 all-http = ["https", "http2"]
-https = ["rustls", "rustls-pemfile", "webpki"]
+https = ["rustls", "rustls-pemfile", "webpki", "async-networking"]
 http2 = ["h2", "https"]
 
 # Graceful shutdown; shutdown.rs
@@ -107,6 +107,8 @@ websocket = ["tokio-tungstenite", "sha-1", "base64", "futures-util"]
 
 # Use tokio's async networking instead of the blocking variant.
 async-networking = ["tokio/net"]
+
+uring = ["tokio-uring", "kvarn_signal/uring", "async-networking"]
 
 # also add to https://kvarn.org/cargo-features.
 

--- a/async/src/lib.rs
+++ b/async/src/lib.rs
@@ -239,6 +239,7 @@ pub mod read {
         }
 
         unsafe { buffer.set_len(buffer.capacity()) };
+        println!("read more!");
         let read_now = tokio::time::timeout(timeout, reader.read(&mut buffer[*read..]))
             .await
             .ok()
@@ -246,6 +247,7 @@ pub mod read {
             .ok()
             .ok_or(Error::Done)?;
         *read += read_now;
+        println!("read more: {read_now}");
         unsafe { buffer.set_len(*read) };
 
         Ok(read_now)
@@ -262,6 +264,7 @@ pub mod read {
         let read = &mut read;
 
         loop {
+            println!("Read more");
             if read_more(&mut buffer, &mut reader, read, max_len, timeout).await? == 0 {
                 break;
             };
@@ -269,7 +272,9 @@ pub mod read {
                 return Err(Error::Syntax);
             }
 
+            println!("if contains");
             if contains_two_newlines(&buffer) {
+                println!("does contain");
                 break;
             }
         }

--- a/async/src/lib.rs
+++ b/async/src/lib.rs
@@ -239,7 +239,6 @@ pub mod read {
         }
 
         unsafe { buffer.set_len(buffer.capacity()) };
-        println!("read more!");
         let read_now = tokio::time::timeout(timeout, reader.read(&mut buffer[*read..]))
             .await
             .ok()
@@ -247,7 +246,6 @@ pub mod read {
             .ok()
             .ok_or(Error::Done)?;
         *read += read_now;
-        println!("read more: {read_now}");
         unsafe { buffer.set_len(*read) };
 
         Ok(read_now)
@@ -264,7 +262,6 @@ pub mod read {
         let read = &mut read;
 
         loop {
-            println!("Read more");
             if read_more(&mut buffer, &mut reader, read, max_len, timeout).await? == 0 {
                 break;
             };
@@ -272,9 +269,7 @@ pub mod read {
                 return Err(Error::Syntax);
             }
 
-            println!("if contains");
             if contains_two_newlines(&buffer) {
-                println!("does contain");
                 break;
             }
         }

--- a/extensions/Cargo.toml
+++ b/extensions/Cargo.toml
@@ -16,7 +16,7 @@ futures-util = "0.3"
 kvarn = { path = "../", default-features = false, version = "0.5" }
 kvarn-fastcgi-client = { version = "0.1", optional = true }
 tokio = { version = "1, >=1.23.1", features = ["fs"] }
-tokio-uring = { git = "https://github.com/tokio-rs/tokio-uring", features = ["bytes"] }
+tokio-uring = { git = "https://github.com/tokio-rs/tokio-uring", features = ["bytes"], optional = true }
 async_chunked_transfer = "1.4"
 percent-encoding = { version = "2", optional = true }
 memchr = "2"
@@ -39,8 +39,9 @@ templates = []
 push = ["url-crawl"]
 reverse-proxy = ["connection", "url-crawl"]
 # Automatic HTTPS certificates
-certificate = ["small-acme", "x509-parser", "rustls", "rustls-pemfile", "ron", "rcgen", "kvarn/https", "kvarn/async-networking", "rand"]
+certificate = ["small-acme", "x509-parser", "rustls", "rustls-pemfile", "ron", "rcgen", "kvarn/https", "rand"]
 view-counter = ["dashmap"]
+uring = ["kvarn/uring", "tokio-uring"]
 
 [dev-dependencies]
 tokio = { version = "1, >=1.23.1", features = ["net", "io-util", "macros"] }

--- a/extensions/Cargo.toml
+++ b/extensions/Cargo.toml
@@ -16,6 +16,7 @@ futures-util = "0.3"
 kvarn = { path = "../", default-features = false, version = "0.5" }
 kvarn-fastcgi-client = { version = "0.1", optional = true }
 tokio = { version = "1, >=1.23.1", features = ["fs"] }
+tokio-uring = { git = "https://github.com/tokio-rs/tokio-uring", features = ["bytes"] }
 async_chunked_transfer = "1.4"
 percent-encoding = { version = "2", optional = true }
 memchr = "2"

--- a/extensions/src/view-counter.rs
+++ b/extensions/src/view-counter.rs
@@ -52,7 +52,7 @@ pub async fn mount(
     let view_count = match parse(&total_path).await {
         Some(x) => x,
         None => {
-            if tokio::fs::metadata(&total_path).await.is_ok() {
+            if tokio_uring::fs::statx(&total_path).await.is_ok() {
                 warn!("Overriding view count total at '{total_path}'");
             }
             ViewCount {
@@ -64,7 +64,7 @@ pub async fn mount(
 
     {
         let c = view_count.clone();
-        tokio::spawn(async move {
+        tokio::task::spawn_local(async move {
             loop {
                 tokio::time::sleep(commit_interval).await;
 
@@ -75,7 +75,7 @@ pub async fn mount(
                     }
                 }
                 if any_changed {
-                    let mut file = match tokio::fs::OpenOptions::new()
+                    let file = match tokio_uring::fs::OpenOptions::new()
                         .create(true)
                         .write(true)
                         .append(true)
@@ -90,10 +90,12 @@ pub async fn mount(
                         }
                         Ok(f) => f,
                     };
-                    if file.metadata().await.unwrap().len() == 0 {
-                        file.write_all(b"article path,view count,Rfc3339 date\n")
-                            .await
-                            .unwrap();
+                    let metadata = tokio_uring::fs::statx(&changes_path)
+                        .await
+                        .expect("Failed to get stat for view counter changes file");
+                    if metadata.stx_size == 0 {
+                        let data = &b"article path,view count,Rfc3339 date\n"[..];
+                        file.write_all_at(data, 0).await.0.unwrap();
                     }
                     let now = chrono::OffsetDateTime::now_utc()
                         .replace_nanosecond(0)
@@ -122,13 +124,12 @@ pub async fn mount(
                                 format!("{article},{count},{date}\n")
                             };
                             debug!("Add to history: {:?}", line.trim_end());
-                            file.write_all(line.as_bytes()).await.unwrap();
+                            file.write_all_at(line.into_bytes(), 0).await.0.unwrap();
                         }
                     }
-                    file.flush().await.unwrap();
                     drop(file);
                     debug!("Updating total");
-                    let mut file = match tokio::fs::File::create(&total_path).await {
+                    let file = match tokio_uring::fs::File::create(&total_path).await {
                         Err(err) => {
                             error!(
                             "Failed to open file to log view count history ('{changes_path}'): {err:?}"
@@ -137,7 +138,7 @@ pub async fn mount(
                         }
                         Ok(f) => f,
                     };
-                    file.write_all(b"article path,view count\n").await.unwrap();
+                    let mut data = b"article path,view count\n".to_vec();
                     for v in c.articles.iter() {
                         let count = v.1;
                         let article = v.key();
@@ -155,9 +156,9 @@ pub async fn mount(
                         } else {
                             format!("{article},{count}\n")
                         };
-                        file.write_all(line.as_bytes()).await.unwrap();
+                        data.append(&mut line.into_bytes());
                     }
-                    file.flush().await.unwrap();
+                    file.write_all_at(data, 0).await.0.unwrap();
                     drop(file);
                 }
             }

--- a/signal/Cargo.toml
+++ b/signal/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["ipc", "kvarn"]
 [dependencies]
 log = "0.4"
 tokio = { version = "1, >=1.23.1", features = ["net", "time", "io-util", "rt", "fs", "sync", "macros"] }
+tokio-uring = { git = "https://github.com/tokio-rs/tokio-uring" }
 notify = { version = "5", default-features = false, features = ["macos_fsevent"] }
 
 [package.metadata.docs.rs]

--- a/signal/Cargo.toml
+++ b/signal/Cargo.toml
@@ -14,8 +14,11 @@ keywords = ["ipc", "kvarn"]
 [dependencies]
 log = "0.4"
 tokio = { version = "1, >=1.23.1", features = ["net", "time", "io-util", "rt", "fs", "sync", "macros"] }
-tokio-uring = { git = "https://github.com/tokio-rs/tokio-uring" }
+tokio-uring = { git = "https://github.com/tokio-rs/tokio-uring", optional = true }
 notify = { version = "5", default-features = false, features = ["macos_fsevent"] }
+
+[features]
+uring = ["tokio-uring"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/application.rs
+++ b/src/application.rs
@@ -7,192 +7,15 @@
 //!
 //! When accepting on the [`HttpConnection`], you get a [`FatRequest`]; a [`http::Request`] with a [`Body`].
 //! The [`Body`] is a stream providing the body of the request if you need it, to avoid unnecessary allocations.
-use std::task::ready;
 
 use crate::prelude::{internals::*, *};
-use futures_util::FutureExt;
 pub use response::Http1Body;
 
-/// Wrapper for `tokio_uring`'s `TcpStream`, to implement [`AsyncRead`] and [`AsyncWrite`]
-/// by using buffers.
-#[allow(clippy::type_complexity)]
-pub struct TcpStreamAsyncWrapper {
-    read_fut: Option<Pin<Box<dyn Future<Output = tokio_uring::BufResult<usize, Vec<u8>>>>>>,
-    write_fut: Option<Pin<Box<dyn Future<Output = tokio_uring::BufResult<(), Vec<u8>>>>>>,
-    read_buf: Option<(Vec<u8>, usize)>,
-    write_buf: Option<Vec<u8>>,
-    stream: TcpStream,
-}
-impl TcpStreamAsyncWrapper {
-    pub(crate) fn new(stream: TcpStream) -> Self {
-        Self {
-            read_fut: None,
-            write_fut: None,
-            read_buf: Some((Vec::with_capacity(1024 * 64), 0)),
-            write_buf: Some(Vec::with_capacity(1024 * 64)),
-            stream,
-        }
-    }
-}
-impl Debug for TcpStreamAsyncWrapper {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct(utils::ident_str!(TcpStreamAsyncWrapper));
+#[cfg(all(feature = "uring", not(feature = "async-networking")))]
+compile_error!("You must enable the 'async-networking' feature to use uring.");
 
-        utils::fmt_fields!(
-            s,
-            (
-                self.read_fut,
-                &self
-                    .read_fut
-                    .as_ref()
-                    .map(|_| "[internal future]".as_clean())
-            ),
-            (
-                self.write_fut,
-                &self
-                    .write_fut
-                    .as_ref()
-                    .map(|_| "[internal future]".as_clean())
-            ),
-            (self.read_buf, &"[internal buffer]".as_clean()),
-            (self.write_fut, &"[internal buffer]".as_clean()),
-            (self.stream, &"[internal stream]".as_clean()),
-        );
-
-        s.finish()
-    }
-}
-impl AsyncRead for TcpStreamAsyncWrapper {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
-        let Self {
-            read_fut,
-            read_buf,
-            stream,
-            ..
-        } = &mut *self;
-
-        // SAFETY: we store the future in the same struct, and as the stream is stored after it, it
-        // gets dropped later: the future's lifetime requirement for stream is met.
-        let stream: &'static TcpStream = unsafe { &*(stream as *const TcpStream) };
-
-        loop {
-            if let Some(read) = read_buf {
-                let len = (read.0.len() - read.1).min(buf.remaining());
-                if len > 0 {
-                    buf.put_slice(&read.0[read.1..read.1 + len]);
-                    read.1 += len;
-
-                    // fill from buffer again
-                    return Poll::Ready(Result::Ok(()));
-                }
-            }
-            if let Some(fut) = read_fut {
-                let (r, mut buf) = ready!(fut.poll_unpin(cx));
-                match r {
-                    Err(err) => return Poll::Ready(Err(err)),
-                    Ok(read) => unsafe { buf.set_len(read) },
-                }
-                if buf.is_empty() {
-                    return Poll::Ready(Ok(()));
-                }
-                *read_buf = Some((buf, 0));
-                *read_fut = None;
-                continue;
-            }
-
-            // read
-            let mut buf = read_buf.take().unwrap().0;
-            unsafe { buf.set_len(buf.capacity()) };
-            let fut = stream.read(buf);
-            *read_fut = Some(Box::pin(fut));
-            // continue
-        }
-    }
-}
-impl AsyncWrite for TcpStreamAsyncWrapper {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        bytes: &[u8],
-    ) -> Poll<Result<usize, io::Error>> {
-        let Self {
-            write_fut,
-            write_buf,
-            stream,
-            ..
-        } = &mut *self;
-
-        // SAFETY: we store the future in the same struct, and as the stream is stored after it, it
-        // gets dropped later: the future's lifetime requirement for stream is met.
-        let stream: &'static TcpStream = unsafe { &*(stream as *const TcpStream) };
-
-        loop {
-            if let Some(buf) = write_buf {
-                let available = buf.capacity() - buf.len();
-                if available == 0 {
-                    let fut = stream.write_all(write_buf.take().unwrap());
-                    let b = Box::pin(fut);
-                    *write_fut = Some(b);
-                    continue;
-                }
-                let append = available.min(bytes.len());
-                buf.extend_from_slice(&bytes[..append]);
-                return Poll::Ready(Ok(append));
-            }
-
-            let fut = write_fut.as_mut().unwrap();
-            let (r, mut buf) = ready!(fut.poll_unpin(cx));
-            unsafe { buf.set_len(0) };
-            *write_buf = Some(buf);
-            *write_fut = None;
-            if let Err(err) = r {
-                return Poll::Ready(Err(err));
-            }
-            // loop to write more
-        }
-    }
-    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        Poll::Ready(self.stream.shutdown(net::Shutdown::Both))
-    }
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        let Self {
-            write_fut,
-            write_buf,
-            stream,
-            ..
-        } = &mut *self;
-
-        // SAFETY: we store the future in the same struct, and as the stream is stored after it, it
-        // gets dropped later: the future's lifetime requirement for stream is met.
-        let stream: &'static TcpStream = unsafe { &*(stream as *const TcpStream) };
-
-        loop {
-            if let Some(buf) = write_buf {
-                if buf.is_empty() {
-                    return Poll::Ready(Ok(()));
-                }
-                let fut = stream.write_all(write_buf.take().unwrap());
-                let b = Box::pin(fut);
-                *write_fut = Some(b);
-                continue;
-            }
-
-            let fut = write_fut.as_mut().unwrap();
-            let (r, mut buf) = ready!(fut.poll_unpin(cx));
-            unsafe { buf.set_len(0) };
-            *write_buf = Some(buf);
-            *write_fut = None;
-            if let Err(err) = r {
-                return Poll::Ready(Err(err));
-            }
-            // loop to write more
-        }
-    }
-}
+#[cfg(feature = "uring")]
+pub use uring_tokio_compat::TcpStreamAsyncWrapper;
 
 /// General error for application-level logic.
 ///
@@ -270,6 +93,7 @@ impl From<Error> for io::Error {
 /// See [`HttpConnection::new`] on how to make one and
 /// [`HttpConnection::accept`] on getting a [`FatRequest`].
 #[derive(Debug)]
+#[must_use]
 pub enum HttpConnection {
     /// A HTTP/1 connection
     Http1(Arc<Mutex<Encryption>>),
@@ -1096,6 +920,198 @@ mod response {
                 }
             } else {
                 Poll::Ready(Ok(()))
+            }
+        }
+    }
+}
+
+#[cfg(feature = "uring")]
+mod uring_tokio_compat {
+    use crate::prelude::*;
+
+    /// Wrapper for `tokio_uring`'s `TcpStream`, to implement [`AsyncRead`] and [`AsyncWrite`]
+    /// by using buffers.
+    #[allow(clippy::type_complexity)]
+    pub struct TcpStreamAsyncWrapper {
+        read_fut: Option<Pin<Box<dyn Future<Output = tokio_uring::BufResult<usize, Vec<u8>>>>>>,
+        write_fut: Option<Pin<Box<dyn Future<Output = tokio_uring::BufResult<(), Vec<u8>>>>>>,
+        read_buf: Option<(Vec<u8>, usize)>,
+        write_buf: Option<Vec<u8>>,
+        stream: tokio_uring::net::TcpStream,
+    }
+    impl TcpStreamAsyncWrapper {
+        pub(crate) fn new(stream: tokio_uring::net::TcpStream) -> Self {
+            Self {
+                read_fut: None,
+                write_fut: None,
+                read_buf: Some((Vec::with_capacity(1024 * 64), 0)),
+                write_buf: Some(Vec::with_capacity(1024 * 64)),
+                stream,
+            }
+        }
+    }
+    impl Debug for TcpStreamAsyncWrapper {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            let mut s = f.debug_struct(utils::ident_str!(TcpStreamAsyncWrapper));
+
+            utils::fmt_fields!(
+                s,
+                (
+                    self.read_fut,
+                    &self
+                        .read_fut
+                        .as_ref()
+                        .map(|_| "[internal future]".as_clean())
+                ),
+                (
+                    self.write_fut,
+                    &self
+                        .write_fut
+                        .as_ref()
+                        .map(|_| "[internal future]".as_clean())
+                ),
+                (self.read_buf, &"[internal buffer]".as_clean()),
+                (self.write_fut, &"[internal buffer]".as_clean()),
+                (self.stream, &"[internal stream]".as_clean()),
+            );
+
+            s.finish()
+        }
+    }
+    impl AsyncRead for TcpStreamAsyncWrapper {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            let Self {
+                read_fut,
+                read_buf,
+                stream,
+                ..
+            } = &mut *self;
+
+            // SAFETY: we store the future in the same struct, and as the stream is stored after it, it
+            // gets dropped later: the future's lifetime requirement for stream is met.
+            let stream: &'static tokio_uring::net::TcpStream =
+                unsafe { &*(stream as *const tokio_uring::net::TcpStream) };
+
+            loop {
+                if let Some(read) = read_buf {
+                    let len = (read.0.len() - read.1).min(buf.remaining());
+                    if len > 0 {
+                        buf.put_slice(&read.0[read.1..read.1 + len]);
+                        read.1 += len;
+
+                        // fill from buffer again
+                        return Poll::Ready(Result::Ok(()));
+                    }
+                }
+                if let Some(fut) = read_fut {
+                    let (r, mut buf) = std::task::ready!(Pin::new(fut).poll(cx));
+                    match r {
+                        Err(err) => return Poll::Ready(Err(err)),
+                        Ok(read) => unsafe { buf.set_len(read) },
+                    }
+                    if buf.is_empty() {
+                        return Poll::Ready(Ok(()));
+                    }
+                    *read_buf = Some((buf, 0));
+                    *read_fut = None;
+                    continue;
+                }
+
+                // read
+                let mut buf = read_buf.take().unwrap().0;
+                unsafe { buf.set_len(buf.capacity()) };
+                let fut = stream.read(buf);
+                *read_fut = Some(Box::pin(fut));
+                // continue
+            }
+        }
+    }
+    impl AsyncWrite for TcpStreamAsyncWrapper {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bytes: &[u8],
+        ) -> Poll<Result<usize, io::Error>> {
+            let Self {
+                write_fut,
+                write_buf,
+                stream,
+                ..
+            } = &mut *self;
+
+            // SAFETY: we store the future in the same struct, and as the stream is stored after it, it
+            // gets dropped later: the future's lifetime requirement for stream is met.
+            let stream: &'static tokio_uring::net::TcpStream =
+                unsafe { &*(stream as *const tokio_uring::net::TcpStream) };
+
+            loop {
+                if let Some(buf) = write_buf {
+                    let available = buf.capacity() - buf.len();
+                    if available == 0 {
+                        let fut = stream.write_all(write_buf.take().unwrap());
+                        let b = Box::pin(fut);
+                        *write_fut = Some(b);
+                        continue;
+                    }
+                    let append = available.min(bytes.len());
+                    buf.extend_from_slice(&bytes[..append]);
+                    return Poll::Ready(Ok(append));
+                }
+
+                let fut = write_fut.as_mut().unwrap();
+                let (r, mut buf) = std::task::ready!(Pin::new(fut).poll(cx));
+                unsafe { buf.set_len(0) };
+                *write_buf = Some(buf);
+                *write_fut = None;
+                if let Err(err) = r {
+                    return Poll::Ready(Err(err));
+                }
+                // loop to write more
+            }
+        }
+        fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+            Poll::Ready(self.stream.shutdown(net::Shutdown::Both))
+        }
+        fn poll_flush(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), io::Error>> {
+            let Self {
+                write_fut,
+                write_buf,
+                stream,
+                ..
+            } = &mut *self;
+
+            // SAFETY: we store the future in the same struct, and as the stream is stored after it, it
+            // gets dropped later: the future's lifetime requirement for stream is met.
+            let stream: &'static tokio_uring::net::TcpStream =
+                unsafe { &*(stream as *const tokio_uring::net::TcpStream) };
+
+            loop {
+                if let Some(buf) = write_buf {
+                    if buf.is_empty() {
+                        return Poll::Ready(Ok(()));
+                    }
+                    let fut = stream.write_all(write_buf.take().unwrap());
+                    let b = Box::pin(fut);
+                    *write_fut = Some(b);
+                    continue;
+                }
+
+                let fut = write_fut.as_mut().unwrap();
+                let (r, mut buf) = std::task::ready!(Pin::new(fut).poll(cx));
+                unsafe { buf.set_len(0) };
+                *write_buf = Some(buf);
+                *write_fut = None;
+                if let Err(err) = r {
+                    return Poll::Ready(Err(err));
+                }
+                // loop to write more
             }
         }
     }

--- a/src/comprash.rs
+++ b/src/comprash.rs
@@ -498,7 +498,7 @@ impl CompressedResponse {
     pub async fn get_gzip(&self, level: u32) -> &Bytes {
         if self.gzip.is_none() {
             let bytes = self.identity.body().clone();
-            let buffer = tokio::task::spawn_blocking(move || {
+            let buffer = threading::spawn_blocking(move || {
                 let mut buffer = utils::WriteableBytes::with_capacity(bytes.len() / 3 + 64);
 
                 // 1-9, 1 is fast, 9 is slow. 4 is equal to brotli's 3
@@ -530,7 +530,7 @@ impl CompressedResponse {
     pub async fn get_br(&self, level: u32) -> &Bytes {
         if self.br.is_none() {
             let bytes = self.identity.body().clone();
-            let buffer = tokio::task::spawn_blocking(move || {
+            let buffer = threading::spawn_blocking(move || {
                 let mut buffer = utils::WriteableBytes::with_capacity(bytes.len() / 3 + 64);
 
                 // 1-10, 1 is fast, 10 is really slow

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -685,7 +685,7 @@ pub(crate) async fn listen(
         .await;
 
         #[cfg(feature = "graceful-shutdown")]
-        spawn(async move {
+        let _task = spawn(async move {
             drop(sd.get_initate_shutdown_watcher().changed().await);
             info!("Send close to ctl socket, because we started shutting down.");
             drop(close_ctl.send(true));

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -587,7 +587,7 @@ pub(crate) async fn listen(
         let supports_shutdown = plugins.plugins.contains_key("shutdown");
 
         if supports_shutdown {
-            match kvarn_signal::unix::send_to(b"shutdown no-wait", &path)
+            match kvarn_signal::unix::send_to(b"shutdown no-wait".to_vec(), &path)
                 .await
                 .as_deref()
             {

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -123,6 +123,7 @@ impl Encryption {
     /// and if the client supports SNI hostnames.
     // change docs for HTTP/3 ↑
     #[inline]
+    #[must_use]
     pub fn server_name(&self) -> Option<&str> {
         match self {
             #[cfg(feature = "https")]

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -16,11 +16,35 @@ use crate::prelude::{internals::*, *};
 ///
 /// Used as the return type for all extensions,
 /// so they can be stored.
+#[cfg(feature = "uring")]
 pub type RetFut<'a, T> = Pin<Box<(dyn Future<Output = T> + 'a)>>;
+/// A return type for a `dyn` [`Future`].
+///
+/// Used as the return type for all extensions,
+/// so they can be stored.
+#[cfg(not(feature = "uring"))]
+pub type RetFut<'a, T> = Pin<Box<(dyn Future<Output = T> + Send + 'a)>>;
 /// Same as [`RetFut`] but also implementing [`Sync`].
 ///
 /// Mostly used for extensions used across yield bounds.
+#[cfg(feature = "uring")]
 pub type RetSyncFut<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+/// Same as [`RetFut`] but also implementing [`Sync`].
+///
+/// Mostly used for extensions used across yield bounds.
+#[cfg(not(feature = "uring"))]
+pub type RetSyncFut<'a, T> = Pin<Box<dyn Future<Output = T> + Send + Sync + 'a>>;
+
+#[cfg(feature = "uring")]
+#[doc(hidden)]
+pub trait KvarnSendSync {}
+#[cfg(feature = "uring")]
+impl<T> KvarnSendSync for T {}
+#[cfg(not(feature = "uring"))]
+#[doc(hidden)]
+pub trait KvarnSendSync: Send + Sync {}
+#[cfg(not(feature = "uring"))]
+impl<T: Send + Sync> KvarnSendSync for T {}
 
 /// A prime extension.
 ///
@@ -31,7 +55,7 @@ pub type RetSyncFut<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 /// See [module level documentation](extensions) and [kvarn.org](https://kvarn.org/extensions/) for more info.
 pub type Prime = Box<dyn PrimeCall>;
 /// Implement this to pass your extension to [`Extensions::add_prime`].
-pub trait PrimeCall {
+pub trait PrimeCall: KvarnSendSync {
     /// # Arguments
     ///
     /// - An immutable reference to the request.
@@ -71,7 +95,7 @@ impl<
 pub type Prepare = Box<dyn PrepareCall>;
 /// Implement this to pass your extension to [`Extensions::add_prepare_fn`] or
 /// [`Extensions::add_prepare_single`].
-pub trait PrepareCall {
+pub trait PrepareCall: KvarnSendSync {
     /// # Arguments
     ///
     /// - A mutable reference to the request.
@@ -93,8 +117,7 @@ impl<
                 Option<&Path>,
                 SocketAddr,
             ) -> RetFut<'a, FatResponse>
-            + Send
-            + Sync,
+            + KvarnSendSync,
     > PrepareCall for F
 {
     fn call<'a>(
@@ -117,7 +140,7 @@ impl<
 pub type Present = Box<dyn PresentCall>;
 /// Implement this to pass your extension to [`Extensions::add_present_file`] or
 /// [`Extensions::add_present_internal`].
-pub trait PresentCall {
+pub trait PresentCall: KvarnSendSync {
     /// # Arguments
     ///
     /// [`PresentData`] contains all the references to the data needed.
@@ -127,7 +150,7 @@ pub trait PresentCall {
     /// > yourself. Only having to dereference one struct was easier.
     fn call<'a>(&'a self, present_data: &'a mut PresentData<'a>) -> RetFut<'a, ()>;
 }
-impl<F: for<'a> Fn(&'a mut PresentData<'a>) -> RetFut<'a, ()> + Send + Sync> PresentCall for F {
+impl<F: for<'a> Fn(&'a mut PresentData<'a>) -> RetFut<'a, ()> + KvarnSendSync> PresentCall for F {
     fn call<'a>(&'a self, present_data: &'a mut PresentData<'a>) -> RetFut<'a, ()> {
         self(present_data)
     }
@@ -141,7 +164,7 @@ impl<F: for<'a> Fn(&'a mut PresentData<'a>) -> RetFut<'a, ()> + Send + Sync> Pre
 /// See [module level documentation](extensions) and [kvarn.org](https://kvarn.org/extensions/) for more info.
 pub type Package = Box<dyn PackageCall>;
 /// Implement this to pass your extension to [`Extensions::add_package`].
-pub trait PackageCall: Send + Sync {
+pub trait PackageCall: KvarnSendSync {
     /// # Arguments
     ///
     /// - A mutable reference to a [`Response`] without the body.
@@ -157,8 +180,7 @@ pub trait PackageCall: Send + Sync {
 }
 impl<
         F: for<'a> Fn(&'a mut Response<()>, &'a FatRequest, &'a Host, SocketAddr) -> RetFut<'a, ()>
-            + Send
-            + Sync,
+            + KvarnSendSync,
     > PackageCall for F
 {
     fn call<'a>(
@@ -180,7 +202,7 @@ impl<
 /// See [module level documentation](extensions) and [kvarn.org](https://kvarn.org/extensions/) for more info.
 pub type Post = Box<dyn PostCall>;
 /// Implement this to pass your extension to [`Extensions::add_post`].
-pub trait PostCall {
+pub trait PostCall: KvarnSendSync {
     /// # Arguments
     ///
     /// - An immutable reference to the request.
@@ -205,8 +227,7 @@ impl<
                 Bytes,
                 SocketAddr,
             ) -> RetFut<'a, ()>
-            + Send
-            + Sync,
+            + KvarnSendSync,
     > PostCall for F
 {
     fn call<'a>(
@@ -223,13 +244,19 @@ impl<
 /// Dynamic function to check if a extension should be ran.
 ///
 /// Used with [`Prepare`] extensions
+#[cfg(feature = "uring")]
+pub type If = Box<(dyn Fn(&FatRequest, &Host) -> bool)>;
+/// Dynamic function to check if a extension should be ran.
+///
+/// Used with [`Prepare`] extensions
+#[cfg(not(feature = "uring"))]
 pub type If = Box<(dyn Fn(&FatRequest, &Host) -> bool + Sync + Send)>;
 /// A [`Future`] for writing to a [`ResponsePipe`] after the response is sent.
 ///
 /// Used with [`Prepare`] extensions in their returned [`FatResponse`].
 pub type ResponsePipeFuture = Box<dyn ResponsePipeFutureCall>;
 /// Implement this to pass your future to [`FatResponse::with_future`].
-pub trait ResponsePipeFutureCall {
+pub trait ResponsePipeFutureCall: KvarnSendSync {
     /// # Arguments
     ///
     /// - A mutable reference to the [`ResponseBodyPipe`].
@@ -323,7 +350,15 @@ impl PartialOrd for Id {
 /// Returns a future accepted by all the [`extensions`]
 /// yielding immediately with `value`.
 #[inline]
+#[cfg(not(feature = "uring"))]
 pub fn ready<'a, T: 'a + Send>(value: T) -> RetFut<'a, T> {
+    Box::pin(core::future::ready(value))
+}
+/// Returns a future accepted by all the [`extensions`]
+/// yielding immediately with `value`.
+#[inline]
+#[cfg(feature = "uring")]
+pub fn ready<'a, T: 'a>(value: T) -> RetFut<'a, T> {
     Box::pin(core::future::ready(value))
 }
 
@@ -1108,9 +1143,16 @@ pub fn stream_body() -> Box<dyn PrepareCall> {
     prepare!(req, host, path, _addr, {
         debug!("Streaming body for {:?}", req.uri().path());
         if let Some(path) = path {
-            let file = tokio_uring::fs::File::open(path).await;
-            let meta = if file.is_ok() {
-                tokio_uring::fs::statx(path).await.ok()
+            let file = fs::File::open(path).await;
+            let meta = if let Ok(_file) = &file {
+                #[cfg(feature = "uring")]
+                {
+                    tokio_uring::fs::statx(path).await.ok()
+                }
+                #[cfg(not(feature = "uring"))]
+                {
+                    _file.metadata().await.ok()
+                }
             } else {
                 None
             };
@@ -1137,37 +1179,46 @@ pub fn stream_body() -> Box<dyn PrepareCall> {
                     response.headers_mut().insert("content-type", content_type);
                 }
 
-                FatResponse::new(response, comprash::ServerCachePreference::None)
-                    .with_future_and_len(
-                        response_pipe_fut!(response, _host, move |file: tokio_uring::fs::File| {
-                            let mut buf = Vec::with_capacity(1024 * 32);
-                            let mut pos = 0;
-                            unsafe { buf.set_len(buf.capacity()) };
-                            loop {
-                                let (r, b) = file.read_at(buf, pos).await;
-                                buf = b;
-                                match r {
-                                    Ok(read) => {
-                                        if read == 0 {
-                                            break;
-                                        }
-                                        pos += read as u64;
-                                        match response.write_all(&buf[..read]).await {
-                                            Ok(()) => {}
-                                            Err(_) => {
-                                                break;
-                                            }
-                                        }
-                                    }
-                                    Err(err) => {
-                                        warn!("Failed to stream body from file: {err}");
+                #[cfg(feature = "uring")]
+                let len = meta.stx_size as usize;
+                #[cfg(not(feature = "uring"))]
+                let len = meta.len() as usize;
+
+                #[cfg(feature = "uring")]
+                let fut = response_pipe_fut!(response, _host, move |file: fs::File| {
+                    let mut buf = Vec::with_capacity(1024 * 32);
+                    let mut pos = 0;
+                    unsafe { buf.set_len(buf.capacity()) };
+                    loop {
+                        let (r, b) = file.read_at(buf, pos).await;
+                        buf = b;
+                        match r {
+                            Ok(read) => {
+                                if read == 0 {
+                                    break;
+                                }
+                                pos += read as u64;
+                                match response.write_all(&buf[..read]).await {
+                                    Ok(()) => {}
+                                    Err(_) => {
                                         break;
                                     }
                                 }
                             }
-                        }),
-                        meta.stx_size as usize,
-                    )
+                            Err(err) => {
+                                warn!("Failed to stream body from file: {err}");
+                                break;
+                            }
+                        }
+                    }
+                });
+                #[cfg(not(feature = "uring"))]
+                let fut = response_pipe_fut!(response, _host, move |file: fs::File| {
+                    let _err = tokio::io::copy(file, response).await;
+                });
+
+                FatResponse::new(response, comprash::ServerCachePreference::None)
+                    .with_future_and_len(fut, len)
             } else {
                 default_error_response(StatusCode::NOT_FOUND, host, None).await
             }
@@ -1234,10 +1285,34 @@ mod macros {
         // `name` for the params is used to locally bind the params, as the `param` can be `_`.
         ($trait: ty, $ret: ty, $(($meta:tt) ,)? | $($param:tt: $param_type:ty: $param_type_no_lifetimes:ty :$name:ident ),* |, $(($($(($mut:tt))? $move:ident:$ty:ty),+))?, $code:block) => {{
             // we go through all this hassle of having a closure to capture dynamic environment.
+            #[cfg(feature = "uring")]
+            // not requirement of Send + Sync
+            struct Ext<F: for<'a> Fn($($param_type,)* $($(&'a $($mut)? $ty,)+)?) -> $crate::extensions::RetFut<'a, $ret>> {
+                ext_function_private: F,
+                $($($move:$ty,)+)?
+            }
+            #[cfg(feature = "uring")]
+            // not requirement of Send + Sync
+            impl<F: for<'a> Fn($($param_type,)* $($(&'a $($mut)? $ty,)+)?) -> $crate::extensions::RetFut<'a, $ret>> $trait for Ext<F> {
+                fn call<'a>(
+                    &'a $($meta)? self,
+                    $($name: $param_type,)*
+                ) -> $crate::extensions::RetFut<'a, $ret> {
+                    let Self {
+                        ext_function_private,
+                        $($($move,)+)?
+                    } = self;
+                    (ext_function_private)($($name,)* $($($move,)+)?)
+                }
+            }
+
+            #[cfg(not(feature = "uring"))]
             struct Ext<F: for<'a> Fn($($param_type,)* $($(&'a $($mut)? $ty,)+)?) -> $crate::extensions::RetFut<'a, $ret> + Send + Sync> {
                 ext_function_private: F,
                 $($($move:$ty,)+)?
             }
+
+            #[cfg(not(feature = "uring"))]
             impl<F: for<'a> Fn($($param_type,)* $($(&'a $($mut)? $ty,)+)?) -> $crate::extensions::RetFut<'a, $ret> + Send + Sync> $trait for Ext<F> {
                 fn call<'a>(
                     &'a $($meta)? self,

--- a/src/host.rs
+++ b/src/host.rs
@@ -960,6 +960,8 @@ impl Collection {
         (found, cleared)
     }
 }
+unsafe impl Send for Collection {}
+unsafe impl Sync for Collection {}
 #[cfg(feature = "https")]
 impl ResolvesServerCert for Collection {
     #[inline]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -44,7 +44,10 @@ pub use utils::{build_bytes, chars::*, parse, parse::SanitizeError, AsCleanDebug
 pub mod fs {
     pub use super::async_bits::*;
     pub use super::read::{file as read_file, file_cached as read_file_cached};
-    pub use tokio_uring::fs::File;
+    #[cfg(not(feature = "uring"))]
+    pub use tokio::fs::{File, OpenOptions};
+    #[cfg(feature = "uring")]
+    pub use tokio_uring::fs::{File, OpenOptions};
 }
 
 /// **Prelude:** networking
@@ -54,9 +57,12 @@ pub mod networking {
     pub use super::async_bits::*;
     #[cfg(not(feature = "async-networking"))]
     pub use std::net::{TcpListener, TcpStream};
-    #[cfg(feature = "async-networking")]
-    pub use tokio_uring::net::{TcpListener, TcpStream};
-    // pub use tokio::net::{TcpListener, TcpSocket, TcpStream};
+    #[cfg(all(feature = "async-networking", not(feature = "uring")))]
+    pub use tokio::net::{TcpListener, TcpSocket, TcpStream};
+    #[cfg(all(feature = "async-networking", feature = "uring"))]
+    pub use {
+        crate::application::TcpStreamAsyncWrapper as TcpStream, tokio_uring::net::TcpListener,
+    };
 }
 
 /// **Prelude:** internal

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -44,7 +44,7 @@ pub use utils::{build_bytes, chars::*, parse, parse::SanitizeError, AsCleanDebug
 pub mod fs {
     pub use super::async_bits::*;
     pub use super::read::{file as read_file, file_cached as read_file_cached};
-    pub use tokio::fs::File;
+    pub use tokio_uring::fs::File;
 }
 
 /// **Prelude:** networking
@@ -55,7 +55,8 @@ pub mod networking {
     #[cfg(not(feature = "async-networking"))]
     pub use std::net::{TcpListener, TcpStream};
     #[cfg(feature = "async-networking")]
-    pub use tokio::net::{TcpListener, TcpSocket, TcpStream};
+    pub use tokio_uring::net::{TcpListener, TcpStream};
+    // pub use tokio::net::{TcpListener, TcpSocket, TcpStream};
 }
 
 /// **Prelude:** internal

--- a/src/read.rs
+++ b/src/read.rs
@@ -17,19 +17,8 @@ pub async fn file_cached<P: AsRef<str>>(path: &P, cache: Option<&FileCache>) -> 
         }
     }
 
-    let file = File::open(path.as_ref()).await.ok()?;
-    let stat = tokio_uring::fs::statx(path.as_ref()).await.ok()?;
-    let len = stat.stx_size;
+    let buffer = read(path.as_ref()).await?;
 
-    #[cfg(target_pointer_width = "32")] // we assume we won't compile to 16-bit targets!
-    if len > (u32::MAX / 2) as u64 {
-        warn!("Tried to read file larger than representable memory (2GB)");
-    }
-
-    #[allow(clippy::cast_possible_truncation)] // we just checked above
-    let buffer = BytesMut::with_capacity(len as _);
-    let (r, buffer) = file.read_at(buffer, 0).await;
-    r.ok()?;
     let buffer = buffer.freeze();
     if let Some(cache) = cache {
         cache
@@ -52,18 +41,34 @@ pub async fn file<P: AsRef<str>>(path: &P, cache: Option<&FileCache>) -> Option<
         }
     }
 
-    let file = File::open(path.as_ref()).await.ok()?;
-    let stat = tokio_uring::fs::statx(path.as_ref()).await.ok()?;
-    let len = stat.stx_size;
+    let buffer = read(path.as_ref()).await?;
 
-    #[cfg(target_pointer_width = "32")] // we assume we won't compile to 16-bit targets!
-    if len > (u32::MAX / 2) as u64 {
-        warn!("Tried to read file larger than representable memory (2GB)");
-    }
-
-    #[allow(clippy::cast_possible_truncation)] // we just checked above
-    let buffer = BytesMut::with_capacity(len as _);
-    let (r, buffer) = file.read_at(buffer, 0).await;
-    r.ok()?;
     Some(buffer.freeze())
+}
+
+async fn read(path: &str) -> Option<BytesMut> {
+    #[cfg(feature = "uring")]
+    {
+        let file = File::open(path).await.ok()?;
+        let stat = tokio_uring::fs::statx(path).await.ok()?;
+        let len = stat.stx_size;
+
+        #[cfg(target_pointer_width = "32")] // we assume we won't compile to 16-bit targets!
+        if len > (u32::MAX / 2) as u64 {
+            warn!("Tried to read file larger than representable memory (2GB)");
+        }
+
+        #[allow(clippy::cast_possible_truncation)] // we just checked above
+        let buffer = BytesMut::with_capacity(len as _);
+        let (r, buffer) = file.read_at(buffer, 0).await;
+        r.ok()?;
+        Some(buffer)
+    }
+    #[cfg(not(feature = "uring"))]
+    {
+        let file = File::open(path).await.ok()?;
+        let mut buffer = BytesMut::with_capacity(4096);
+        async_bits::read_to_end(&mut buffer, file).await.ok()?;
+        Some(buffer)
+    }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -18,8 +18,18 @@ pub async fn file_cached<P: AsRef<str>>(path: &P, cache: Option<&FileCache>) -> 
     }
 
     let file = File::open(path.as_ref()).await.ok()?;
-    let mut buffer = BytesMut::with_capacity(4096);
-    async_bits::read_to_end(&mut buffer, file).await.ok()?;
+    let stat = tokio_uring::fs::statx(path.as_ref()).await.ok()?;
+    let len = stat.stx_size;
+
+    #[cfg(target_pointer_width = "32")] // we assume we won't compile to 16-bit targets!
+    if len > (u32::MAX / 2) as u64 {
+        warn!("Tried to read file larger than representable memory (2GB)");
+    }
+
+    #[allow(clippy::cast_possible_truncation)] // we just checked above
+    let buffer = BytesMut::with_capacity(len as _);
+    let (r, buffer) = file.read_at(buffer, 0).await;
+    r.ok()?;
     let buffer = buffer.freeze();
     if let Some(cache) = cache {
         cache
@@ -43,7 +53,17 @@ pub async fn file<P: AsRef<str>>(path: &P, cache: Option<&FileCache>) -> Option<
     }
 
     let file = File::open(path.as_ref()).await.ok()?;
-    let mut buffer = BytesMut::with_capacity(4096);
-    async_bits::read_to_end(&mut buffer, file).await.ok()?;
+    let stat = tokio_uring::fs::statx(path.as_ref()).await.ok()?;
+    let len = stat.stx_size;
+
+    #[cfg(target_pointer_width = "32")] // we assume we won't compile to 16-bit targets!
+    if len > (u32::MAX / 2) as u64 {
+        warn!("Tried to read file larger than representable memory (2GB)");
+    }
+
+    #[allow(clippy::cast_possible_truncation)] // we just checked above
+    let buffer = BytesMut::with_capacity(len as _);
+    let (r, buffer) = file.read_at(buffer, 0).await;
+    r.ok()?;
     Some(buffer.freeze())
 }


### PR DESCRIPTION
Improves performance when this feature is enabled.
Requires a recent Linux kernel.

~~We should maybe make all "version" of Kvarn single-threaded, to keep consistency? We could also use Rc in some places.~~ Rc and RefCell wouldn't change a lot, since the hosts are still multi-threaded. And it would be impossible to bind the same socket from multiple threads on Windows. And dropping windows support isn't on my todo-list.