### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ compact_str = "0.7.0"
 log = "0.4"
 time = { version = "0.3", features = ["parsing", "formatting", "macros"] }
 
-h2 = { version = "0.3", default-features = false, optional = true }
+h2 = { version = "0.3.17", default-features = false, optional = true }
 http = "0.2"
 mime = "0.3"
 mime_guess = "2"


### PR DESCRIPTION
Updates dependency to the patch version of 0.3.17

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0034.html)